### PR TITLE
Fix LSP for Emacs with Eglot: handle workspace/didChangeConfiguration notification

### DIFF
--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 
 pub const CONFIG_SECTION: &str = "tablegen-lsp";
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Config {
     pub include_dirs: Vec<FilePath>,
     pub default_source_root_path: Option<FilePath>,

--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -4,10 +4,10 @@ use std::ops::ControlFlow;
 use std::sync::Arc;
 
 use async_lsp::lsp_types::{
-    CompletionOptions, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
-    DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentLinkOptions,
-    FoldingRangeProviderCapability, HoverProviderCapability, InitializeParams, InitializeResult,
-    MessageType, OneOf, PublishDiagnosticsParams, ServerCapabilities, ServerInfo,
+    CompletionOptions, DidChangeConfigurationParams, DidChangeTextDocumentParams,
+    DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams,
+    DocumentLinkOptions, FoldingRangeProviderCapability, HoverProviderCapability, InitializeParams,
+    InitializeResult, MessageType, OneOf, PublishDiagnosticsParams, ServerCapabilities, ServerInfo,
     ShowMessageParams, SignatureHelpOptions, TextDocumentSyncCapability, TextDocumentSyncKind, Url,
     notification, request,
 };
@@ -23,7 +23,7 @@ use ide::analysis::{Analysis, AnalysisHost, Cancellable, Cancelled};
 use ide::file_system::{FileId, FilePath, FileSystem, SourceUnitId};
 use ide::index::Index;
 
-use crate::config::Config;
+use crate::config::{Config, CONFIG_SECTION};
 use crate::diagnostics::DiagnosticCollection;
 use crate::pending_changes::PendingChanges;
 use crate::progress::Progress;
@@ -76,6 +76,7 @@ impl Server {
             .notification::<notification::DidCloseTextDocument>(Self::did_close)
             .notification::<lsp_ext::SetSourceRoot>(Self::set_source_root)
             .notification::<lsp_ext::ClearSourceRoot>(Self::clear_source_root)
+            .notification::<notification::DidChangeConfiguration>(Self::did_change_configuration)
             .request_snap::<request::DocumentSymbolRequest>(handlers::document_symbol)
             .request_snap::<request::GotoDefinition>(handlers::definition)
             .request_snap::<request::References>(handlers::references)
@@ -283,6 +284,24 @@ impl Server {
         self.spawn_update_diagnostics();
         ControlFlow::Continue(())
     }
+
+    fn did_change_configuration(
+        &mut self,
+        params: DidChangeConfigurationParams,
+    ) -> <Self as LanguageServer>::NotifyResult {
+        tracing::info!("did_change_configuration: {params:?}");
+        // Eglot (and some other clients) nest settings under the config section key.
+        let settings = params
+            .settings
+            .get(CONFIG_SECTION)
+            .cloned()
+            .unwrap_or(params.settings);
+        let result = self.client.emit(UpdateConfigEvent(settings));
+        if let Err(err) = result {
+            tracing::warn!("failed to emit update config event: {err:?}");
+        }
+        ControlFlow::Continue(())
+    }
 }
 
 impl Server {
@@ -482,7 +501,8 @@ impl Server {
     ) -> <Self as LanguageServer>::NotifyResult {
         tracing::info!("update_config: {v:?}");
 
-        let config = Arc::get_mut(&mut self.config).expect("cannot get mutable reference");
+        // Clone-and-replace so this works even when snapshots hold Arc<Config> clones.
+        let mut config = (*self.config).clone();
         if let Err(err) = config.update(v) {
             self.client
                 .show_message(ShowMessageParams {
@@ -493,7 +513,10 @@ impl Server {
             return ControlFlow::Continue(());
         }
 
-        if let Some(source_root_path) = config.default_source_root_path.clone()
+        let source_root_path = config.default_source_root_path.clone();
+        self.config = Arc::new(config);
+
+        if let Some(source_root_path) = source_root_path
             && let Err(err) = self.set_source_root_impl(source_root_path)
         {
             let message = format!("tablegen-lsp: failed to set source root: {err}");


### PR DESCRIPTION
The server crashes every time Emacs connects with Eglot, because Eglot sends `workspace/didChangeConfiguration` as part of its connect hook, but this notification type is not handled by the server. 

I'm not very familiar with Rust, so I asked Claude to implement support for this notification, and it worked. Also lightly tested with VSCode, which shouldn't be affected.

## Emacs configuration example

The following incantation hardcodes the include paths and the source root, but determines the path of `llvm-project` dynamically (when a `.td` file is opened), so correctly handles files from different git worktrees. I haven't tried to configure it to change the "source root" dynamically.

```
(require 'eglot)

;; Associate tablegen-mode with tablegen-lsp
;; Source: https://github.com/arata-nvm/tablegen-lsp
;; Compute initializationOptions from project root at connection time.
;; Paths assume LLVM project structure with AMDGPU backend.
(add-to-list 'eglot-server-programs
             `(tablegen-mode
               . ,(lambda (&optional _interactive)
                    (let ((root (if-let ((proj (project-current)))
                                    (project-root proj)
                                  default-directory)))
                      `("/path/to/tablegen-lsp"
                        :initializationOptions
                        (:includePath [,(expand-file-name "llvm/lib/Target/AMDGPU" root)
                                       ,(expand-file-name "build/include" root)
                                       ,(expand-file-name "llvm/include" root)]
                         :defaultSourceRootPath
                         ,(expand-file-name "llvm/lib/Target/AMDGPU/AMDGPU.td" root)))))))

;; Enable Eglot automatically when opening .td files
(add-hook 'tablegen-mode-hook 'eglot-ensure)
```

## Build dependency

I tried to build this project from source on Ubuntu follow the basic
instructions from the README, but it failed because of the submodule
for `tblgen-rs-alt` that requires at least LLVM 21.0, according to Claude's explanation:

  > The C++ wrapper used getDirectSuperClasses() with the LLVM 21 API (which returns a range), but LLVM 20 has a different signature that requires an output argument. Building against LLVM 20 headers failed to compile the C++ wrapper.

This worked for me:

```
git clone --recurse-submodules https://github.com/arata-nvm/tablegen-lsp
cd tablegen-lsp
TABLEGEN_210_PREFIX=/usr/lib/llvm-21 cargo build --release
```
It may be worth documenting the dependency somewhere.